### PR TITLE
build: add rsync to standard image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   && apt-get install -y --no-install-recommends \
     curl \
     git \
-    ncat
+    ncat \
+    rsync
 
 COPY --from=helm /helm /usr/bin/helm
 COPY --from=kubectl /kubectl /usr/bin/kubectl


### PR DESCRIPTION
Adds `rsync` to the Debian package set for the `standard` image target, making it available in both standard and heavy images.
