### PR TITLE
ci(renovate): use the actions semver helper; fix/feat for image deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":semanticCommitTypeAll(deps)",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
   "semanticCommits": "enabled",

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":semanticCommitTypeAll(deps)"
+    ":semanticCommitTypeAll(deps)",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "semanticCommits": "enabled",
   "semanticCommitType": "deps",
@@ -48,8 +49,19 @@
         "dockerfile",
         "custom.regex"
       ],
-      "semanticCommitType": "build",
+      "semanticCommitType": "fix",
       "semanticCommitScope": "image"
+    },
+    {
+      "description": "A major image tool bump changes what the image ships",
+      "matchManagers": [
+        "dockerfile",
+        "custom.regex"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "semanticCommitType": "feat"
     },
     {
       "description": "Patch bumps of image tools are low-risk once the build passes",
@@ -98,18 +110,7 @@
       ],
       "semanticCommitType": "ci",
       "semanticCommitScope": "actions",
-      "pinDigests": true,
-      "versioning": "semver",
       "automerge": true
-    },
-    {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "automerge": false
     },
     {
       "description": "Majors always get a human",


### PR DESCRIPTION
Switches the GitHub Actions rules to Renovate's `helpers:pinGitHubActionDigestsToSemver` preset, and changes image-dependency commit types to `fix` / `feat`.

## Changes

**Actions semver helper.** Replaces the hand-rolled `pinDigests: true` + `versioning: "semver"` on the `github-actions` rule with the bundled preset. Two concrete improvements:

- The preset matches `depType: action`, not the whole manager — so it no longer applies semver versioning to the `ubuntu-latest` runner dep, which isn't a semver value at all.
- Its `extractVersion` (`^(?<version>v?\d+\.\d+\.\d+)$`) forces the digest comment to a full three-part version. Confirmed by a local lookup: actions now resolve `v7.0.0` rather than `v7`.

**Image commit types.** `build(image):` becomes `fix(image):`, with majors as `feat(image):`. Rule ordering matters here — the `feat` override sits after the `fix` rule so it wins for majors, and the trailing "majors always get a human" rule only sets `addLabels`/`automerge`, so it doesn't clobber the type.

**Removed a redundant rule.** The `github-actions` + `major` → `automerge: false` rule is already covered by the trailing all-majors rule, which matches every manager and runs last.

## Verification

`renovate-config-validator` passes. A local `--dry-run=lookup` against the working tree resolves all 23 managed dependencies with zero warnings, and shows the action values shifting to three-part semver.

The commit types themselves resolve during branchify, which a lookup dry run doesn't reach. This PR's own `renovate` check now exercises the full `RENOVATE_DRY_RUN=full` path for the first time — `renovate.json` reached the default branch in #45, so the bootstrap gate no longer skips it — and its log carries the generated titles.

## Caveats

Majors are typed `feat`, not `feat!`. Nothing in this repo consumes conventional commits for release automation today, so the marker would be cosmetic; say the word if you'd rather they carry the breaking-change `!`.