### PR TITLE
build: cache layers in a GHCR registry cache

### DIFF
--- a/buildermaster.sh
+++ b/buildermaster.sh
@@ -8,6 +8,11 @@ PLATFORMS=("linux/amd64" "linux/arm64")
 REPOS=("ericmiller/toolbox" "ghcr.io/sosheskaz/toolbox")
 TARGETS=(lite lint standard heavy)
 
+# Layer cache lives beside the images on GHCR, one ref per target. The package is
+# public, so PR builds import it without credentials; only the push path has the
+# credentials to export.
+CACHE_REPO="${CACHE_REPO:-ghcr.io/sosheskaz/toolbox}"
+
 PLATFORMS_CSV="$(IFS=,; echo "${PLATFORMS[*]}")"
 
 BUILDARGS=()
@@ -33,10 +38,22 @@ do
     fi
   done
 
+  CACHEARGS=()
+  if [[ "${NOCACHE:-false}" != "true" ]]
+  then
+    # Importing a ref that does not exist yet logs an error and continues, so the
+    # first build of a new target needs no special-casing.
+    CACHEARGS+=("--cache-from=type=registry,ref=${CACHE_REPO}:buildcache-${TARGET}")
+    if [[ "${PUSH:-false}" = "true" ]]
+    then CACHEARGS+=("--cache-to=type=registry,ref=${CACHE_REPO}:buildcache-${TARGET},mode=max")
+    fi
+  fi
+
   docker buildx build \
     --platform="${PLATFORMS_CSV}" \
     "${TAGARGS[@]}" \
     --target="${TARGET}" \
     "${BUILDARGS[@]}" \
+    "${CACHEARGS[@]}" \
     .
 done


### PR DESCRIPTION
Adds a buildx registry cache so builds stop starting cold. One cache ref per target, stored beside the images on GHCR.

## Why now

Every build in this repo starts from scratch — `buildermaster.sh` passes no `--cache-from`/`--cache-to`. That was tolerable when the auto-updater opened a single batched PR per week. Renovate opens a PR *per dependency*, and each one runs a full 4-target × 2-platform build at roughly 6 minutes. The first Renovate pass alone produced 10 PRs, so 10 independent cold builds. Cold builds are now the dominant CI cost.

## Design

`--cache-from` on every build; `--cache-to=…,mode=max` only when `PUSH=true`.

That split follows from credentials: `push.yml` logs into GHCR and can export, while `pr.yml` has no registry auth. Since `ghcr.io/sosheskaz/toolbox` is a **public** package (verified with an anonymous `crane ls`), PR builds import the cache without credentials. So PRs read whatever cache `main` last wrote — the standard shape, and the one that actually helps, since PR builds are what's slow.

Cache refs are tags on the existing package (`:buildcache-<target>`) rather than a separate package. A separate package would be tidier, but new GHCR packages default to **private**, which would silently break anonymous imports from PRs until someone flipped visibility by hand. The cost is four extra tags in `crane ls` output.

`mode=max` caches intermediate stages too, which matters here — the expensive layers are the seven per-tool download stages and the `apt-get`/`uv tool install` steps, none of which are in the final image's layer chain.

## Verification

`shellcheck` passes. Argument construction tested against a stubbed `docker` across all three paths:

| Path | Result |
|---|---|
| PR (`PUSH` unset) | `--cache-from` only |
| Push (`PUSH=true`) | `--cache-from` + `--cache-to=…,mode=max` |
| `NOCACHE=true` | no cache args, `--no-cache`, exit 0 |

That last row matters because `CACHEARGS` is empty there and the script runs under `set -u`.

Separately confirmed that importing a **nonexistent** ref is non-fatal: buildx logs `ERROR: failed to configure registry cache importer: … not found` and the build still exits 0. So no bootstrap special-casing is needed.

## Caveats

This PR's own build gets **no speedup** and will log that cache-import error, because no cache exists yet. The first `main` push after merge populates it; builds after that are the ones to measure. Worth comparing a later Renovate PR's build time against the ~6 minutes they take today.

`PULL` still defaults to `true`, so base images are re-pulled every build regardless of cache. That's deliberate — it keeps `debian`/`alpine` fresh — but it does mean the `FROM` layers aren't fully cache-served.