### PR TITLE
ci(renovate): only run on pushes that change renovate's config

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,9 +1,18 @@
 name: Renovate
 
 on:  # yamllint disable-line rule:truthy
+  # The cron is the cadence. A push run exists only to apply a config change
+  # immediately instead of waiting up to six hours for the next scheduled run,
+  # so it is filtered to the files that decide renovate's behaviour. Keep this
+  # list identical to the pull_request one below (Actions does not support YAML
+  # anchors, so it has to be repeated).
   push:
     branches:
       - main
+    paths:
+      - renovate.json
+      - mise.toml
+      - .github/workflows/renovate.yml
   schedule:
     - cron: '0 */6 * * *'
   pull_request:


### PR DESCRIPTION
Filters the Renovate workflow's `push` trigger to the same paths its `pull_request` trigger already uses, so a merge only starts a Renovate run when it actually changed how Renovate behaves.

## Why

Today every merge to `main` starts a Renovate run, regardless of what it touched. The 6-hourly cron is what provides the cadence; a push-triggered run only earns its keep when the config itself changed, where waiting up to six hours to apply it is the wrong answer.

The two path lists are now identical and must stay that way. GitHub Actions doesn't support YAML anchors, so it's a literal duplicate with a comment saying so.

## Design

`## Behaviour change` — worth knowing before merging.

Merging a **dependency** PR no longer triggers a Renovate run. Two consequences:

- **The automerge cascade stops.** Right now, merging a Renovate PR kicks off a run that can immediately automerge the next green one. After this, automerges happen only on the cron, so a batch of eligible PRs drains over hours rather than in a chain.
- **Retitles and rebases are deferred** to the next scheduled run, up to six hours out.

Neither loses work — the cron picks everything up — but the repo will feel less immediately reactive after merging a dependency bump. `workflow_dispatch` is still there to force a run, and remains unsuppressed because `renovate.json` sets `schedule: ["at any time"]` rather than a restrictive window.

If that tradeoff isn't wanted, the alternative is to leave `push` unfiltered and accept redundant runs; they're cheap (~20-40s) but they do re-clone and re-resolve every datasource each time.

## Verification

`actionlint` and `zizmor` pass. Confirmed the two path lists are byte-identical:

```
diff <(yq -r '.on.push.paths[]' …) <(yq -r '.on.pull_request.paths[]' …)  # IDENTICAL
```

This PR changes `.github/workflows/renovate.yml`, which is in the filter, so its own merge exercises the new trigger — if the path filter were wrong, no Renovate run would follow the merge.