### PR TITLE
build: remove kcl from the images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ ARG CRANE_VERSION=v0.21.7
 ARG GITHUB_CLI_VERSION=2.96.0
 # renovate: datasource=github-releases depName=helm/helm extractVersion=^v(?<version>.+)$
 ARG HELM_VERSION=4.2.3
-# renovate: datasource=github-releases depName=kcl-lang/cli
-ARG KCL_VERSION=v0.10.0
 # renovate: datasource=github-releases depName=kubernetes/kubernetes extractVersion=^v(?<version>.+)$
 ARG KUBECTL_VERSION=1.36.2
 # renovate: datasource=github-releases depName=stackrox/kube-linter extractVersion=^v(?<version>.+)$
@@ -93,16 +91,6 @@ RUN --mount=type=tmpfs,target=/tmp \
   suffix=${TARGETOS}_${TARGETARCH}; if [ "${TARGETARCH}" = "amd64" ]; then suffix="${TARGETOS}"; fi; \
   curl -fsSL https://github.com/stackrox/kube-linter/releases/download/v${KUBE_LINTER_VERSION}/kube-linter-${suffix}.tar.gz -o /tmp/kube-linter.tar.gz \
   && tar -C /usr/bin -xzf /tmp/kube-linter.tar.gz
-
-FROM --platform=$BUILDPLATFORM downloader AS kcl
-
-ARG KCL_VERSION
-ARG TARGETOS
-ARG TARGETARCH
-RUN --mount=type=tmpfs,target=/tmp \
-  curl -fsSL https://github.com/kcl-lang/cli/releases/download/${KCL_VERSION}/kcl-${KCL_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz -o /tmp/kcl.tar.gz \
-  && tar -C /tmp -xzf /tmp/kcl.tar.gz \
-  && mv /tmp/kcl /usr/bin/kcl
 
 FROM --platform=$BUILDPLATFORM downloader AS gh
 ARG GITHUB_CLI_VERSION
@@ -181,7 +169,6 @@ COPY --from=kubectl /kubectl /usr/bin/kubectl
 COPY --from=kustomize /kustomize /usr/bin/kustomize
 
 FROM standard AS heavy
-COPY --from=kcl /usr/bin/kcl /usr/bin/kcl
 COPY --from=gh /usr/bin/gh /usr/bin/gh
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/README.md
+++ b/README.md
@@ -70,6 +70,5 @@ Includes everything in **standard**, plus:
 | Tool | Description |
 |------|-------------|
 | gh | GitHub CLI |
-| kcl | KCL configuration language CLI |
 | nmap | Network scanner |
 | python3 | Python runtime |


### PR DESCRIPTION
Removes the KCL CLI from the `heavy` image.

Drops the `KCL_VERSION` arg and its Renovate annotation, the whole `kcl` download stage, the `COPY --from=kcl` into `heavy`, and the README row. No other target referenced it.

## Verification

`git grep -i kcl` returns nothing. `hadolint` passes. A local `--platform=local --dry-run=lookup` shows the custom regex manager dropping from 11 deps to 10, with everything else still resolving. The `heavy` target — the only one that shipped kcl — builds clean.

## Caveats

Renovate PR #52 (`fix(image): update dependency kcl-lang/cli to v0.12.7`) becomes obsolete once this merges. Renovate closes PRs whose dependency no longer exists, so it should self-close on the next run rather than needing manual cleanup.

`heavy` still carries `nmap`, `python3` and `gh`, so this shrinks the image but doesn't change its character.