### PR TITLE
ci(renovate): enable osv vulnerability alerts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
   "prHourlyLimit": 0,
   "prConcurrentLimit": 10,
   "minimumReleaseAgeBehaviour": "timestamp-optional",
+  "osvVulnerabilityAlerts": true,
   "ignorePaths": [
     ".worktrees/**"
   ],


### PR DESCRIPTION
Sets `osvVulnerabilityAlerts: true`, so Renovate queries osv.dev for known vulnerabilities in the dependencies it already manages and raises fix PRs, instead of only proposing routine version bumps.

## What this actually covers

Worth being precise, because the coverage is narrower than "scans the image for CVEs". Renovate checks OSV for the dependencies *it manages*, and OSV's ecosystem coverage across our datasources is uneven:

| Datasource | Deps | OSV coverage |
|---|---|---|
| `pypi` | 4 | good — ansible-lint, ruff, uv, yamllint |
| `npm` | 1 | good — renovate itself |
| `github-releases` / `github-tags` | 21 | partial, via GitHub Security Advisories |
| `docker` | 7 | none — OSV does not index image tags |

So it meaningfully covers the PyPI and npm dependencies, and partially covers the tools fetched from GitHub releases. It does **not** find CVEs in the Debian packages inside the built images — that would need an image scanner, which is a separate question.

## Interaction with minimumReleaseAge

This repo holds patch/minor updates for 7 days. That would be the wrong behaviour for a security fix, but no extra config is needed: Renovate's `vulnerabilityAlerts` object already defaults to `minimumReleaseAge: null` (along with `prCreation: "immediate"` and a `[SECURITY]` commit suffix), so fix branches bypass the delay.

## Verification

`renovate-config-validator` passes. A local `--dry-run=lookup` still resolves every managed dependency with no warnings and unchanged per-manager counts.

## Caveats

`osvVulnerabilityAlerts` is flagged **experimental** in Renovate (renovatebot/renovate#20542). It has been stable in practice for a long time, but it is not a settled API.

Fix PRs land outside the usual `fix(image)` / `ci(mise)` scoping — they get Renovate's `[SECURITY]` commit suffix and their own branch topic.