### PR TITLE
feat(image): add claude and codex agent targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ ARG KUBECTL_VERSION=1.36.2
 ARG KUBE_LINTER_VERSION=0.8.3
 # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize extractVersion=^kustomize/(?<version>v.+)$
 ARG KUSTOMIZE_VERSION=v5.8.1
+# renovate: datasource=node-version depName=node
+ARG NODE_VERSION=24.18.1
+# renovate: datasource=npm depName=@anthropic-ai/claude-code
+ARG CLAUDE_CODE_VERSION=2.1.220
 # renovate: datasource=pypi depName=ansible-lint
 ARG ANSIBLE_LINT_VERSION=26.6.0
 # renovate: datasource=pypi depName=ruff
@@ -101,6 +105,15 @@ RUN --mount=type=tmpfs,target=/tmp \
   && tar -C /tmp -xzf /tmp/gh.tar.gz \
   && mv /tmp/gh_${GITHUB_CLI_VERSION}_${TARGETOS}_${TARGETARCH}/bin/gh /usr/bin/gh
 
+FROM --platform=$BUILDPLATFORM downloader AS node
+ARG NODE_VERSION
+ARG TARGETARCH
+RUN --mount=type=tmpfs,target=/tmp \
+  arch=${TARGETARCH}; if [ "${TARGETARCH}" = "amd64" ]; then arch=x64; fi; \
+  curl -fsSL https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${arch}.tar.gz -o /tmp/node.tar.gz \
+  && mkdir -p /node \
+  && tar -C /node --strip-components=1 -xzf /tmp/node.tar.gz
+
 FROM debian:${DEBIAN_VERSION} AS lite
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -178,5 +191,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     nmap \
     python3 \
     python3-pip
+
+FROM heavy AS claude
+ARG CLAUDE_CODE_VERSION
+
+# The Node tarball unpacks straight into /usr/local, which is both npm's default
+# global prefix and already on PATH, so the `claude` shim needs no extra wiring.
+COPY --from=node /node /usr/local
+
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
+  && npm cache clean --force \
+  && claude --version
 
 FROM standard AS default

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,9 @@ ARG KUBECTL_VERSION=1.36.2
 ARG KUBE_LINTER_VERSION=0.8.3
 # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize extractVersion=^kustomize/(?<version>v.+)$
 ARG KUSTOMIZE_VERSION=v5.8.1
-# renovate: datasource=node-version depName=node
-ARG NODE_VERSION=24.18.1
-# renovate: datasource=npm depName=@anthropic-ai/claude-code
+# renovate: datasource=github-releases depName=anthropics/claude-code extractVersion=^v(?<version>.+)$
 ARG CLAUDE_CODE_VERSION=2.1.220
-# renovate: datasource=npm depName=@openai/codex
+# renovate: datasource=github-releases depName=openai/codex extractVersion=^rust-v(?<version>.+)$
 ARG CODEX_VERSION=0.146.0
 # renovate: datasource=github-releases depName=jdx/mise extractVersion=^v(?<version>.+)$
 ARG MISE_VERSION=2026.8.0
@@ -108,15 +106,6 @@ RUN --mount=type=tmpfs,target=/tmp \
   curl -fsSL https://github.com/cli/cli/releases/download/v${GITHUB_CLI_VERSION}/gh_${GITHUB_CLI_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz -o /tmp/gh.tar.gz \
   && tar -C /tmp -xzf /tmp/gh.tar.gz \
   && mv /tmp/gh_${GITHUB_CLI_VERSION}_${TARGETOS}_${TARGETARCH}/bin/gh /usr/bin/gh
-
-FROM --platform=$BUILDPLATFORM downloader AS node
-ARG NODE_VERSION
-ARG TARGETARCH
-RUN --mount=type=tmpfs,target=/tmp \
-  arch=${TARGETARCH}; if [ "${TARGETARCH}" = "amd64" ]; then arch=x64; fi; \
-  curl -fsSL https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${arch}.tar.gz -o /tmp/node.tar.gz \
-  && mkdir -p /node \
-  && tar -C /node --strip-components=1 -xzf /tmp/node.tar.gz
 
 FROM --platform=$BUILDPLATFORM downloader AS mise
 ARG MISE_VERSION
@@ -213,24 +202,25 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 FROM heavy AS agent-base
 
-# The Node tarball unpacks straight into /usr/local, which is both npm's default
-# global prefix and already on PATH, so the agent shims need no extra wiring.
-COPY --from=node /node /usr/local
+# Both agents ship a native binary, so mise installs them directly and no Node
+# runtime is needed. Data and config live outside $HOME so the shims resolve
+# whichever user the image runs as.
+ENV MISE_DATA_DIR=/opt/mise \
+    MISE_CONFIG_DIR=/opt/mise \
+    PATH=/opt/mise/shims:${PATH}
 
 FROM agent-base AS claude
 ARG CLAUDE_CODE_VERSION
 
-RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
-  && npm cache clean --force \
+RUN mise use -g -y claude@${CLAUDE_CODE_VERSION} \
   && claude --version
 
 FROM agent-base AS codex
 ARG CODEX_VERSION
 
-# The package selects a per-architecture native binary through optional
-# dependencies, so this install must run on the target platform, not the builder.
-RUN npm install -g @openai/codex@${CODEX_VERSION} \
-  && npm cache clean --force \
+# codex ships helper binaries beside the entrypoint, so it is installed through
+# shims rather than symlinking one path out of the install directory.
+RUN mise use -g -y codex@${CODEX_VERSION} \
   && codex --version
 
 FROM standard AS default

--- a/Dockerfile
+++ b/Dockerfile
@@ -187,12 +187,17 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   && apt-get install -y --no-install-recommends \
     curl \
     git \
+    less \
     ncat \
+    ripgrep \
     rsync
 
 COPY --from=helm /helm /usr/bin/helm
 COPY --from=kubectl /kubectl /usr/bin/kubectl
 COPY --from=kustomize /kustomize /usr/bin/kustomize
+# mise resolves each repo's own pinned toolchain from its config, so the image
+# ships the launcher rather than a guess at which tools a repo wants.
+COPY --from=mise /mise /usr/bin/mise
 
 FROM standard AS heavy
 COPY --from=gh /usr/bin/gh /usr/bin/gh
@@ -202,31 +207,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   apt-get update \
   && apt-get install -y --no-install-recommends \
     nmap \
+    openssh-client \
     python3 \
     python3-pip
 
 FROM heavy AS agent-base
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-  apt-get update \
-  && apt-get install -y --no-install-recommends \
-    less \
-    openssh-client \
-    python3-virtualenv \
-    ripgrep
-
 # The Node tarball unpacks straight into /usr/local, which is both npm's default
 # global prefix and already on PATH, so the agent shims need no extra wiring.
 COPY --from=node /node /usr/local
-# mise resolves each repo's own pinned toolchain from its config, so the image
-# ships the launcher rather than a guess at which tools a repo wants.
-COPY --from=mise /mise /usr/bin/mise
-
-ARG UV_VERSION
-RUN virtualenv /opt/uv \
-  && /opt/uv/bin/pip install uv==${UV_VERSION} \
-  && ln -s /opt/uv/bin/uv /usr/bin/
 
 FROM agent-base AS claude
 ARG CLAUDE_CODE_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ ARG NODE_VERSION=24.18.1
 ARG CLAUDE_CODE_VERSION=2.1.220
 # renovate: datasource=npm depName=@openai/codex
 ARG CODEX_VERSION=0.146.0
+# renovate: datasource=github-releases depName=jdx/mise extractVersion=^v(?<version>.+)$
+ARG MISE_VERSION=2026.8.0
 # renovate: datasource=pypi depName=ansible-lint
 ARG ANSIBLE_LINT_VERSION=26.6.0
 # renovate: datasource=pypi depName=ruff
@@ -116,6 +118,15 @@ RUN --mount=type=tmpfs,target=/tmp \
   && mkdir -p /node \
   && tar -C /node --strip-components=1 -xzf /tmp/node.tar.gz
 
+FROM --platform=$BUILDPLATFORM downloader AS mise
+ARG MISE_VERSION
+ARG TARGETARCH
+RUN --mount=type=tmpfs,target=/tmp \
+  arch=${TARGETARCH}; if [ "${TARGETARCH}" = "amd64" ]; then arch=x64; fi; \
+  curl -fsSL https://github.com/jdx/mise/releases/download/v${MISE_VERSION}/mise-v${MISE_VERSION}-linux-${arch}.tar.gz -o /tmp/mise.tar.gz \
+  && tar -C /tmp -xzf /tmp/mise.tar.gz \
+  && mv /tmp/mise/bin/mise /mise
+
 FROM debian:${DEBIAN_VERSION} AS lite
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -194,21 +205,38 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     python3 \
     python3-pip
 
-FROM heavy AS claude
-ARG CLAUDE_CODE_VERSION
+FROM heavy AS agent-base
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+  apt-get update \
+  && apt-get install -y --no-install-recommends \
+    less \
+    openssh-client \
+    python3-virtualenv \
+    ripgrep
 
 # The Node tarball unpacks straight into /usr/local, which is both npm's default
-# global prefix and already on PATH, so the `claude` shim needs no extra wiring.
+# global prefix and already on PATH, so the agent shims need no extra wiring.
 COPY --from=node /node /usr/local
+# mise resolves each repo's own pinned toolchain from its config, so the image
+# ships the launcher rather than a guess at which tools a repo wants.
+COPY --from=mise /mise /usr/bin/mise
+
+ARG UV_VERSION
+RUN virtualenv /opt/uv \
+  && /opt/uv/bin/pip install uv==${UV_VERSION} \
+  && ln -s /opt/uv/bin/uv /usr/bin/
+
+FROM agent-base AS claude
+ARG CLAUDE_CODE_VERSION
 
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
   && npm cache clean --force \
   && claude --version
 
-FROM heavy AS codex
+FROM agent-base AS codex
 ARG CODEX_VERSION
-
-COPY --from=node /node /usr/local
 
 # The package selects a per-architecture native binary through optional
 # dependencies, so this install must run on the target platform, not the builder.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ ARG KUSTOMIZE_VERSION=v5.8.1
 ARG NODE_VERSION=24.18.1
 # renovate: datasource=npm depName=@anthropic-ai/claude-code
 ARG CLAUDE_CODE_VERSION=2.1.220
+# renovate: datasource=npm depName=@openai/codex
+ARG CODEX_VERSION=0.146.0
 # renovate: datasource=pypi depName=ansible-lint
 ARG ANSIBLE_LINT_VERSION=26.6.0
 # renovate: datasource=pypi depName=ruff
@@ -202,5 +204,16 @@ COPY --from=node /node /usr/local
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
   && npm cache clean --force \
   && claude --version
+
+FROM heavy AS codex
+ARG CODEX_VERSION
+
+COPY --from=node /node /usr/local
+
+# The package selects a per-architecture native binary through optional
+# dependencies, so this install must run on the target platform, not the builder.
+RUN npm install -g @openai/codex@${CODEX_VERSION} \
+  && npm cache clean --force \
+  && codex --version
 
 FROM standard AS default

--- a/Dockerfile
+++ b/Dockerfile
@@ -191,6 +191,12 @@ COPY --from=mise /mise /usr/bin/mise
 FROM standard AS heavy
 COPY --from=gh /usr/bin/gh /usr/bin/gh
 
+# mise data and config live outside $HOME so anything installed through it
+# resolves for whichever user the image runs as, not just root.
+ENV MISE_DATA_DIR=/opt/mise \
+    MISE_CONFIG_DIR=/opt/mise \
+    PATH=/opt/mise/shims:${PATH}
+
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
   apt-get update \
@@ -200,22 +206,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     python3 \
     python3-pip
 
-FROM heavy AS agent-base
-
-# Both agents ship a native binary, so mise installs them directly and no Node
-# runtime is needed. Data and config live outside $HOME so the shims resolve
-# whichever user the image runs as.
-ENV MISE_DATA_DIR=/opt/mise \
-    MISE_CONFIG_DIR=/opt/mise \
-    PATH=/opt/mise/shims:${PATH}
-
-FROM agent-base AS claude
+# Both agents ship a native binary, so mise installs them directly with no Node
+# runtime involved.
+FROM heavy AS claude
 ARG CLAUDE_CODE_VERSION
 
 RUN mise use -g -y claude@${CLAUDE_CODE_VERSION} \
   && claude --version
 
-FROM agent-base AS codex
+FROM heavy AS codex
 ARG CODEX_VERSION
 
 # codex ships helper binaries beside the entrypoint, so it is installed through

--- a/README.md
+++ b/README.md
@@ -79,23 +79,23 @@ Includes everything in **standard**, plus:
 
 ### claude
 
-Heavy, plus the Claude Code CLI and the Node.js runtime it needs.
+Heavy, plus the Claude Code CLI.
 
 Includes everything in **heavy**, plus:
 
 | Tool | Description |
 |------|-------------|
-| node | Node.js runtime (also provides `npm`) |
 | claude | Claude Code CLI |
 
 ### codex
 
-Heavy, plus the Codex CLI and the Node.js runtime it needs. Identical to
-**claude** except for the agent itself.
+Heavy, plus the Codex CLI. Identical to **claude** except for the agent itself.
 
 Includes everything in **heavy**, plus:
 
 | Tool | Description |
 |------|-------------|
-| node | Node.js runtime (also provides `npm`) |
 | codex | Codex CLI |
+
+Both agents are installed with `mise` into `/opt/mise`, which is on `PATH` via
+its shims. Neither needs a Node.js runtime.

--- a/README.md
+++ b/README.md
@@ -75,22 +75,33 @@ Includes everything in **standard**, plus:
 
 ### claude
 
-Heavy, plus the Claude Code CLI and the Node.js runtime it needs.
+Heavy, plus coding-agent tooling and the Claude Code CLI.
 
 Includes everything in **heavy**, plus:
 
 | Tool | Description |
 |------|-------------|
 | node | Node.js runtime (also provides `npm`) |
+| mise | Version manager; resolves a repo's own pinned toolchain |
+| uv | Python package manager |
+| ripgrep | Fast recursive search (`rg`) |
+| openssh-client | Git over SSH |
+| less | Pager, used by `git` |
 | claude | Claude Code CLI |
 
 ### codex
 
-Heavy, plus the Codex CLI and the Node.js runtime it needs.
+Heavy, plus coding-agent tooling and the Codex CLI. Identical to **claude**
+except for the agent itself.
 
 Includes everything in **heavy**, plus:
 
 | Tool | Description |
 |------|-------------|
 | node | Node.js runtime (also provides `npm`) |
+| mise | Version manager; resolves a repo's own pinned toolchain |
+| uv | Python package manager |
+| ripgrep | Fast recursive search (`rg`) |
+| openssh-client | Git over SSH |
+| less | Pager, used by `git` |
 | codex | Codex CLI |

--- a/README.md
+++ b/README.md
@@ -83,3 +83,14 @@ Includes everything in **heavy**, plus:
 |------|-------------|
 | node | Node.js runtime (also provides `npm`) |
 | claude | Claude Code CLI |
+
+### codex
+
+Heavy, plus the Codex CLI and the Node.js runtime it needs.
+
+Includes everything in **heavy**, plus:
+
+| Tool | Description |
+|------|-------------|
+| node | Node.js runtime (also provides `npm`) |
+| codex | Codex CLI |

--- a/README.md
+++ b/README.md
@@ -72,3 +72,14 @@ Includes everything in **standard**, plus:
 | gh | GitHub CLI |
 | nmap | Network scanner |
 | python3 | Python runtime |
+
+### claude
+
+Heavy, plus the Claude Code CLI and the Node.js runtime it needs.
+
+Includes everything in **heavy**, plus:
+
+| Tool | Description |
+|------|-------------|
+| node | Node.js runtime (also provides `npm`) |
+| claude | Claude Code CLI |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ Includes everything in **lite**, plus:
 | Tool | Description |
 |------|-------------|
 | git | Version control |
+| less | Pager, used by `git` |
+| mise | Version manager; resolves a repo's own pinned toolchain |
 | ncat | Networking utility (nmap project) |
+| ripgrep | Fast recursive search (`rg`) |
 | kubectl | Kubernetes CLI |
 | helm | Kubernetes package manager |
 | kustomize | Kubernetes manifest customization |
@@ -71,37 +74,28 @@ Includes everything in **standard**, plus:
 |------|-------------|
 | gh | GitHub CLI |
 | nmap | Network scanner |
+| openssh-client | Git over SSH |
 | python3 | Python runtime |
 
 ### claude
 
-Heavy, plus coding-agent tooling and the Claude Code CLI.
+Heavy, plus the Claude Code CLI and the Node.js runtime it needs.
 
 Includes everything in **heavy**, plus:
 
 | Tool | Description |
 |------|-------------|
 | node | Node.js runtime (also provides `npm`) |
-| mise | Version manager; resolves a repo's own pinned toolchain |
-| uv | Python package manager |
-| ripgrep | Fast recursive search (`rg`) |
-| openssh-client | Git over SSH |
-| less | Pager, used by `git` |
 | claude | Claude Code CLI |
 
 ### codex
 
-Heavy, plus coding-agent tooling and the Codex CLI. Identical to **claude**
-except for the agent itself.
+Heavy, plus the Codex CLI and the Node.js runtime it needs. Identical to
+**claude** except for the agent itself.
 
 Includes everything in **heavy**, plus:
 
 | Tool | Description |
 |------|-------------|
 | node | Node.js runtime (also provides `npm`) |
-| mise | Version manager; resolves a repo's own pinned toolchain |
-| uv | Python package manager |
-| ripgrep | Fast recursive search (`rg`) |
-| openssh-client | Git over SSH |
-| less | Pager, used by `git` |
 | codex | Codex CLI |

--- a/buildermaster.sh
+++ b/buildermaster.sh
@@ -6,7 +6,7 @@ export DOCKER_BUILDKIT=1
 
 PLATFORMS=("linux/amd64" "linux/arm64")
 REPOS=("ericmiller/toolbox" "ghcr.io/sosheskaz/toolbox")
-TARGETS=(lite lint standard heavy claude)
+TARGETS=(lite lint standard heavy claude codex)
 
 # Layer cache lives beside the images on GHCR, one ref per target. The package is
 # public, so PR builds import it without credentials; only the push path has the

--- a/buildermaster.sh
+++ b/buildermaster.sh
@@ -6,7 +6,7 @@ export DOCKER_BUILDKIT=1
 
 PLATFORMS=("linux/amd64" "linux/arm64")
 REPOS=("ericmiller/toolbox" "ghcr.io/sosheskaz/toolbox")
-TARGETS=(lite lint standard heavy)
+TARGETS=(lite lint standard heavy claude)
 
 # Layer cache lives beside the images on GHCR, one ref per target. The package is
 # public, so PR builds import it without credentials; only the push path has the

--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,14 @@
       "minimumReleaseAge": "14 days"
     },
     {
+      "description": "Agent CLIs release constantly and the build is the gate; a soak period only holds the image at a stale version",
+      "matchDepNames": [
+        "anthropics/claude-code",
+        "openai/codex"
+      ],
+      "minimumReleaseAge": "0 days"
+    },
+    {
       "description": "Image tool versions — the PR build is the gate",
       "matchManagers": [
         "dockerfile",


### PR DESCRIPTION
Adds two build targets carrying the Claude Code and Codex CLIs, so the agents can
be run in a container for headless or CI use rather than only on a workstation.
Also promotes some general-purpose tooling into the lower targets.

## Changes

- `standard` gains `mise`, `ripgrep` and `less`
- `heavy` gains `openssh-client` and the mise data/config/PATH settings
- new `claude` and `codex` targets over `heavy`

## Design

The new general-purpose tools land in **`standard`, not the agent targets**.
They are not agent-specific: `ripgrep` and `less` are broadly useful, and `mise`
matters anywhere a repo pins its own toolchain. `openssh-client` sits in `heavy`
because git-over-SSH belongs with the rest of that target's VCS tooling.

**Both agents install through `mise`, with no Node.js runtime.** The obvious
route is `npm install -g`, and that works — but it drags in a whole Node
runtime for two programs that are already native binaries. mise is in the image
anyway and its registry maps both to their upstream releases, so it installs
them directly. That is ~55 MB smaller per image and removes a runtime neither
agent actually needs. The version pins therefore track `github-releases` rather
than `npm`, matching where the binaries come from.

Installs go through mise **shims** rather than symlinking a binary out of the
install directory, because the two upstreams lay their releases out differently
— codex ships helper binaries beside its entrypoint, claude does not.
`MISE_DATA_DIR` and `MISE_CONFIG_DIR` point at `/opt/mise` so the shims resolve
for whatever user the image runs as, not just root. Those settings live in
`heavy` rather than an agent-only layer, since they describe where mise keeps
state rather than anything agent-specific.

The two agents get **separate targets** rather than one combined image. They are
useful independently — a job running `codex exec` has no reason to carry Claude
Code — and keeping them apart means a bump to one CLI does not churn the other's
layers. A combined target can be added later if a caller genuinely needs both.

## Caveats

- **`heavy` gains environment variables it did not have before.** Anything
  consuming the published `heavy` tag now sees `MISE_DATA_DIR`/`MISE_CONFIG_DIR`
  set to `/opt/mise` and `/opt/mise/shims` prepended to `PATH`. `standard` and
  `latest` are unaffected.
- `lint` branches from `lite` rather than `standard`, so it does not inherit
  `mise`, `ripgrep` or `less`. That follows the existing structure; calling it
  out because the target list makes it look like a descendant.
- The pinned mise release is hours old at time of writing, so it has had no
  soak. Renovate's `minimumReleaseAge` governs future bumps but not this pin —
  and the agent CLIs are now explicitly exempt from the soak period, since both
  ship near-daily and the build is the real gate.
- `mise use -g` writes a global config at `/opt/mise/config.toml`. A repo's own
  mise config still merges over it, which is the intended precedence, but it
  does mean the image ships a non-empty global mise state.

## Verification

CI built both new targets on **both** platforms, and each target's in-build
smoke test reported the expected version on each:

```
[linux/amd64 claude 1/1] RUN mise use -g -y claude@2.1.220   -> 2.1.220 (Claude Code)
[linux/arm64 claude 1/1] RUN mise use -g -y claude@2.1.220   -> 2.1.220 (Claude Code)
[linux/amd64 codex  1/1] RUN mise use -g -y codex@0.146.0    -> codex-cli 0.146.0
[linux/arm64 codex  1/1] RUN mise use -g -y codex@0.146.0    -> codex-cli 0.146.0
```

Locally on arm64, the shims also resolve for a non-root user. Sizes: standard
182 MB, heavy 221 MB, claude 303 MB, codex 347 MB.